### PR TITLE
Aria label fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "turnstone",
-  "version": "1.4.0",
+  "version": "2.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "turnstone",
-      "version": "1.4.0",
+      "version": "2.2.0",
       "license": "MIT",
       "dependencies": {
         "escape-string-regexp": "^5.0.0",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -32,6 +32,7 @@ const App = () => {
      <div style={{display:'inline-block'}}>
         <label htmlFor="autocomplete">Search Fruits:</label>&nbsp;
         <Turnstone
+          id={'search-fruits'}
           clearButton={true}
           debounceWait={0}
           errorMessage={'Houston we have a problem'}
@@ -48,6 +49,7 @@ const App = () => {
       <div style={{display:'inline-block'}}>
         <label htmlFor="autocomplete">Search Fruits &amp; Veg:</label>&nbsp;
         <Turnstone
+          id={'search-fruits-veg'}
           clearButton={true}
           debounceWait={0}
           errorMessage={'Something is broken'}

--- a/src/lib/components/__snapshots__/container.test.jsx.snap
+++ b/src/lib/components/__snapshots__/container.test.jsx.snap
@@ -4,20 +4,20 @@ exports[`Container > Component renders correctly 1`] = `
 <div
   aria-expanded={false}
   aria-haspopup="listbox"
-  aria-owns="autocomplete-listbox"
+  aria-owns="autocomplete-listbox autocomplete-errorbox"
   className="query-container-class"
   role="combobox"
 >
   <input
     aria-autocomplete="both"
-    aria-controls="autocomplete-listbox"
+    aria-controls="autocomplete-listbox autocomplete-errorbox"
     autoCapitalize="off"
     autoComplete="off"
     autoCorrect="off"
     autoFocus={true}
     className="query-class"
     enterKeyHint="search"
-    id="autocomplete"
+    id="autocomplete-listbox"
     onBlur={[Function]}
     onFocus={[Function]}
     onInput={[Function]}

--- a/src/lib/components/container.jsx
+++ b/src/lib/components/container.jsx
@@ -242,10 +242,10 @@ const Container = React.forwardRef((props, ref) => {
         style={defaultContainerStyles}
         role='combobox'
         aria-expanded={isExpanded}
-        aria-owns={listboxId}
+        aria-owns={[listboxId, errorboxId].join(' ')}
         aria-haspopup='listbox'>
         <input
-          id={id}
+          id={`${id}-listbox`}
           name={name}
           className={`${inputStyles || ''} ${styles.query || ''}`.trim()}
           style={queryDefaultStyle}
@@ -265,7 +265,7 @@ const Container = React.forwardRef((props, ref) => {
           onFocus={handleFocus}
           onBlur={handleBlur}
           aria-autocomplete='both'
-          aria-controls={listboxId}
+          aria-controls={[listboxId, errorboxId].join(' ')}
         />
 
         {hasTypeahead && (
@@ -317,7 +317,7 @@ const Container = React.forwardRef((props, ref) => {
         )}
 
         {isErrorExpanded && (
-          <Errorbox id={errorboxId} errorMessage={errorMessage} styles={styles} />
+          <Errorbox id={`${errorboxId}-errorbox`} errorMessage={errorMessage} styles={styles} />
         )}
       </div>
     </React.Fragment>


### PR DESCRIPTION
Fix for Issue #12. Changes the aria-owner and aria-controls tags to reference the concatenated `{id}-listbox` _and_ `{id}-errorbox` child components. Fixes error in Axe Devtools.